### PR TITLE
fix(plugin): link tags should be set to their link text

### DIFF
--- a/packages/eslint-plugin-isaacscript/src/completeSentence.ts
+++ b/packages/eslint-plugin-isaacscript/src/completeSentence.ts
@@ -86,7 +86,10 @@ function splitOnSpecialText(text: string): string[] {
 
   // Remove link tags. (If we replace them with a sentence separator instead, then the following
   // sentence would fail: Get the name of a peripheral wrapped with {@link peripheral.wrap}.
-  text = text.replaceAll(/{@link.*}/g, "");
+  text = text.replaceAll(
+    /\[([^\]]*)\]\{@link [^} |]+\}|\{@link ([^} |]+)[ |]?\}|\{@link [^} |]+[ |]([^}]+)\}/gm,
+    "$1$2$3",
+  );
 
   // Remove pipes (which indicate a Markdown table).
   text = text.replaceAll("|", SENTENCE_SEPARATOR_IDENTIFIER);

--- a/packages/eslint-plugin-isaacscript/src/completeSentence.ts
+++ b/packages/eslint-plugin-isaacscript/src/completeSentence.ts
@@ -84,9 +84,9 @@ function splitOnSpecialText(text: string): string[] {
   );
   text = text.replaceAll(/@example[\s\S]*/gm, "");
 
-  // Remove link tags. Note that if we replace them with a sentence separator instead, then the
-  // following sentence would fail: Get the name of a peripheral wrapped with {@link
-  // peripheral.wrap}.
+  // Replace the link tags with the link text. Note that if we replace them with a sentence
+  // separator instead, then the following sentence would fail: Get the name of a peripheral wrapped
+  // with {@link peripheral.wrap}.
   // https://regex101.com/r/0u8hQG/1
   // https://jsdoc.app/tags-inline-link.html
   text = text.replaceAll(

--- a/packages/eslint-plugin-isaacscript/tests/rules/complete-sentences-jsdoc.test.ts
+++ b/packages/eslint-plugin-isaacscript/tests/rules/complete-sentences-jsdoc.test.ts
@@ -541,6 +541,21 @@ valid.push({
   `,
 });
 
+valid.push({
+  name: "Comment with capitalized JSDoc link tag",
+  code: `
+/**
+ * {@link NamepathOrURL} it doesn't allow this.
+ *
+ * [Link text]{@link namepathOrURL} hey, it actually starts with a capital letter.
+ *
+ * {@link namepathOrURL|Link text} what do you mean it doesn't start with a capital letter?
+ *
+ * {@link namepathOrURL Link text (after the first space)} this does indeed start with a capital letter.
+ */
+  `,
+});
+
 ruleTester.run("complete-sentences-jsdoc", completeSentencesJSDoc, {
   valid,
   invalid,


### PR DESCRIPTION
To prevent it saying that the sentence doesn't start with a capital letter, probably not the only issue with just removing all link tags