### PR TITLE
fix(plugin): formatting would sometimes break link tags

### DIFF
--- a/packages/eslint-plugin-isaacscript/src/format.ts
+++ b/packages/eslint-plugin-isaacscript/src/format.ts
@@ -319,9 +319,22 @@ function shouldSplitToNewLine(
   effectiveLength: number,
 ) {
   const atBeginningOfLine = formattedLine === "";
+
+  let linkTagStarted = false;
+  for (let i = formattedLine.length; i >= 6; i--) {
+    if (formattedLine[i] === "}") {
+      break;
+    } else if (formattedLine.slice(i - 6, i) === "{@link") {
+      linkTagStarted = true;
+      break;
+    }
+  }
+
   const textToAdd = atBeginningOfLine ? word : ` ${word}`;
   const lineLengthIfAdded = formattedLine.length + textToAdd.length;
-  return lineLengthIfAdded > effectiveLength && !atBeginningOfLine;
+  return (
+    lineLengthIfAdded > effectiveLength && !atBeginningOfLine && !linkTagStarted
+  );
 }
 
 function appendLineToText(

--- a/packages/eslint-plugin-isaacscript/src/format.ts
+++ b/packages/eslint-plugin-isaacscript/src/format.ts
@@ -308,7 +308,8 @@ export function formatText(
 /**
  * We split to a new line if:
  * 1. adding the word would make it overflow past the maximum length
- * 2. and there is at least one word on the current line
+ * 2. there is at least one word on the current line
+ * 3. we are not currently inside a link tag
  *
  * For example, there could be a very long URL that exceeds the maximum length, but since there are
  * no spaces in the URL, it can't be split up and has to exceed the maximum length.

--- a/packages/eslint-plugin-isaacscript/tests/rules/format-jsdoc-comments.test.ts
+++ b/packages/eslint-plugin-isaacscript/tests/rules/format-jsdoc-comments.test.ts
@@ -655,6 +655,15 @@ valid.push({
   `,
 });
 
+valid.push({
+  name: "Comment with overflowing JSDoc link tag",
+  code: `
+/**
+ * Asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd asd {@link colors}.
+ */
+  `,
+});
+
 ruleTester.run("format-jsdoc-comments", formatJSDocComments, {
   valid,
   invalid,


### PR DESCRIPTION
If you have a link tag at almost the max length of a line it will get cut and broken by the formatting