### PR TITLE
fix: do not override stored item pool

### DIFF
--- a/packages/isaacscript-common/src/classes/features/other/CollectibleItemPoolType.ts
+++ b/packages/isaacscript-common/src/classes/features/other/CollectibleItemPoolType.ts
@@ -46,11 +46,14 @@ export class CollectibleItemPoolType extends Feature {
   // ModCallback.POST_PICKUP_INIT (34)
   // PickupVariant.COLLECTIBLE (100)
   private postPickupInitCollectible = (collectible: EntityPickup) => {
-    const itemPool = game.GetItemPool();
     const pickupIndex = this.pickupIndexCreation.getPickupIndex(collectible);
-    const lastItemPoolType = itemPool.GetLastPool();
 
-    v.run.collectibleItemPoolTypeMap.set(pickupIndex, lastItemPoolType);
+    if (!v.run.collectibleItemPoolTypeMap.has(pickupIndex)) {
+      const itemPool = game.GetItemPool();
+      const lastItemPoolType = itemPool.GetLastPool();
+
+      v.run.collectibleItemPoolTypeMap.set(pickupIndex, lastItemPoolType);
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes a bug where the stored item pool of a collectible is overriden with the pool of the most recent collectible when re-entering the room containing it

E.g.:
1. Enter treasure room, see a collectible (it is from the pool 'TREASURE')
2. Exit treasure room, enter shop, see another collectible (it is from the pool 'SHOP')
3. Exit shop, re-enter treasure room, the first collectible is now wrongly considered as coming from the pool 'SHOP'