### PR TITLE
Fix typo in peerDependencies

### DIFF
--- a/packages/eslint-plugin-isaacscript/package.json
+++ b/packages/eslint-plugin-isaacscript/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/utils": "^6.2.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/plugin": ">= 6.0.0",
+    "@typescript-eslint/eslint-plugin": ">= 6.0.0",
     "eslint": ">= 8.0.0",
     "typescript": ">= 5.0.0"
   }


### PR DESCRIPTION
fixes warning:

```
warning " > eslint-plugin-isaacscript@3.0.2" has unmet peer dependency "@typescript-eslint/plugin@>= 6.0.0".
```