### PR TITLE
Invalid path for ISAACSCRIPT_COMMON_PATH

### DIFF
--- a/packages/isaacscript-cli/src/customStage.ts
+++ b/packages/isaacscript-cli/src/customStage.ts
@@ -38,7 +38,6 @@ const ISAACSCRIPT_COMMON_PATH = path.join(
   "node_modules",
   ISAACSCRIPT_COMMON,
   "dist",
-  "src",
 );
 
 const METADATA_LUA_PATH = path.join(


### PR DESCRIPTION
### Changes
* ISAACSCRIPT_COMMON_PATH was including a "src" directory, which would not exist in the distribution of `isaacscript-common`; this causes Custom Stages to not work at compile time due to a failed isDirectory check: https://github.com/IsaacScript/isaacscript/blob/1125c918bac30d12678ac21893055da0da89372a/packages/isaacscript-cli/src/customStage.ts#L228-L238